### PR TITLE
Update fallback addresses

### DIFF
--- a/PingPlugin/GameAddressDetectors/ClientStateAddressDetector.cs
+++ b/PingPlugin/GameAddressDetectors/ClientStateAddressDetector.cs
@@ -60,13 +60,13 @@ namespace PingPlugin.GameAddressDetectors
             {
                 // I just copied these from https://is.xivup.com/adv
                 1 => IPAddress.Parse("124.150.157.23"), // Elemental
-                2 => IPAddress.Parse("124.150.157.36"), // Gaia
+                2 => IPAddress.Parse("124.150.157.38"), // Gaia
                 3 => IPAddress.Parse("124.150.157.49"), // Mana
-                4 => IPAddress.Parse("204.2.229.84"),   // Aether
-                5 => IPAddress.Parse("204.2.229.95"),   // Primal
-                6 => IPAddress.Parse("195.82.50.46"),   // Chaos
-                7 => IPAddress.Parse("195.82.50.55"),   // Light
-                8 => IPAddress.Parse("204.2.229.106"),  // Crystal
+                4 => IPAddress.Parse("204.2.29.70"),   // Aether
+                5 => IPAddress.Parse("204.2.29.82"),   // Primal
+                6 => IPAddress.Parse("80.239.145.79"),   // Chaos
+                7 => IPAddress.Parse("80.239.145.91"),   // Light
+                8 => IPAddress.Parse("204.2.29.94"),  // Crystal
                 9 => IPAddress.Parse("153.254.80.75"),  // Materia
 
                 // If you have CN/KR DC IDs and IP addresses, feel free to PR them.


### PR DESCRIPTION
Apparently SE changed the IP block they use for NA servers, which has been giving me issues while using mudfish alongside with this plugin.

I also noticed that there are some DCs missing (Dynamis and Meteor), I would add them but I dont know their IDs (neither were to look for them)

I also updated some IPs that were different from https://is.xivup.com/adv