### PR TITLE
Fix stuck IP Address logic in ClientStateAddressDetector

### DIFF
--- a/PingPlugin/GameAddressDetectors/ClientStateAddressDetector.cs
+++ b/PingPlugin/GameAddressDetectors/ClientStateAddressDetector.cs
@@ -28,7 +28,7 @@ namespace PingPlugin.GameAddressDetectors
             try
             {
                 dcId = this.clientState.LocalPlayer!.CurrentWorld.GameData?.DataCenter.Row;
-                if (dcId == null || dcId == this.lastDcId) return Address;
+                if ((dcId == null || dcId == this.lastDcId) && !IPAddress.IsLoopback(Address)) return Address;
                 this.lastDcId = (uint)dcId;
             }
             catch (InvalidOperationException)


### PR DESCRIPTION
This is an issue I was having for a while now.
Basically after sometime the ping would show 0ms and an plugin restart was needed in order to fix it.

After some digging, i tracked down the bug as being an rare condition where the ClientStateAddressDetector would check for the LocalPLayer while the player was joining or leaving an instance, in that loading time the LocalPLayer would become null and the ClientStateAddressDetector would set the Address to 127.0.0.1, the issue was after this the logic would not let it reach the switch again to grab the correct address resulting in it being stuck with the loopback address.

![image](https://github.com/karashiiro/PingPlugin/assets/9062212/106a66a5-684c-46f2-93cb-718a74e6f661)

My solution is a simple and quick one, checking to see if the address is the loopback address before returning in the dc Id check.
