### PR TITLE
Fix task being started a second time

### DIFF
--- a/PingPlugin/PingPlugin.cs
+++ b/PingPlugin/PingPlugin.cs
@@ -45,7 +45,6 @@ namespace PingPlugin
             
             this.pingTracker = RequestNewPingTracker(this.config.TrackingMode);
             this.pingTracker.Verbose = false;
-            this.pingTracker.Start();
 
             InitIpc();
 


### PR DESCRIPTION
I could not really find a reason behind this second call of the start method, atm its starting a second task of ping loop and a second task of the address detector loop, it seems like a mistake. Sorry if its not and im just dumb.