### PR TITLE
Reintroduce game packets ping tracker

### DIFF
--- a/PingPlugin/PingPlugin.cs
+++ b/PingPlugin/PingPlugin.cs
@@ -13,6 +13,7 @@ namespace PingPlugin
     {
         private readonly IDalamudPluginInterface pluginInterface;
         private readonly IPluginLog pluginLog;
+        private readonly IGameInteropProvider gameInteropProvider;
 
         private readonly PluginCommandManager<PingPlugin> pluginCommandManager;
         private readonly PingConfiguration config;
@@ -26,10 +27,16 @@ namespace PingPlugin
 
         public string Name => "PingPlugin";
 
-        public PingPlugin(IDalamudPluginInterface pluginInterface, ICommandManager commands, IDtrBar dtrBar, IPluginLog pluginLog)
+        public PingPlugin(
+            IDalamudPluginInterface pluginInterface,
+            ICommandManager commands,
+            IDtrBar dtrBar,
+            IPluginLog pluginLog,
+            IGameInteropProvider gameInteropProvider)
         {
             this.pluginInterface = pluginInterface;
             this.pluginLog = pluginLog;
+            this.gameInteropProvider = gameInteropProvider;
             
             this.config = (PingConfiguration)this.pluginInterface.GetPluginConfig() ?? new PingConfiguration();
             this.config.Initialize(this.pluginInterface, this.pluginLog);
@@ -77,15 +84,27 @@ namespace PingPlugin
         {
             if (WineDetector.IsWINE())
             {
-                // Only reliable tracker under WINE
-                return new IpHlpApiPingTracker(this.config, this.addressDetector, this.pluginLog);
+                return kind switch
+                {
+                    PingTrackerKind.Packets => new PacketPingTracker(
+                        this.config,
+                        this.addressDetector,
+                        this.pluginLog,
+                        this.gameInteropProvider),
+                    _ => new IpHlpApiPingTracker(this.config, this.addressDetector, this.pluginLog),
+                };
             }
             
             return kind switch
             {
-                PingTrackerKind.Aggregate or PingTrackerKind.Packets => new AggregatePingTracker(this.config, this.addressDetector, this.pluginLog),
+                PingTrackerKind.Aggregate => new AggregatePingTracker(this.config, this.addressDetector, this.pluginLog),
                 PingTrackerKind.COM => new ComponentModelPingTracker(this.config, this.addressDetector, this.pluginLog),
                 PingTrackerKind.IpHlpApi => new IpHlpApiPingTracker(this.config, this.addressDetector, this.pluginLog),
+                PingTrackerKind.Packets => new PacketPingTracker(
+                    this.config,
+                    this.addressDetector,
+                    this.pluginLog,
+                    this.gameInteropProvider),
                 _ => RequestFallbackPingTracker(kind),
             };
         }

--- a/PingPlugin/PingPlugin.cs
+++ b/PingPlugin/PingPlugin.cs
@@ -87,24 +87,19 @@ namespace PingPlugin
                 return kind switch
                 {
                     PingTrackerKind.Packets => new PacketPingTracker(
-                        this.config,
-                        this.addressDetector,
-                        this.pluginLog,
-                        this.gameInteropProvider),
+                        this.config, this.addressDetector, this.pluginLog, this.gameInteropProvider),
                     _ => new IpHlpApiPingTracker(this.config, this.addressDetector, this.pluginLog),
                 };
             }
             
             return kind switch
             {
-                PingTrackerKind.Aggregate => new AggregatePingTracker(this.config, this.addressDetector, this.pluginLog),
+                PingTrackerKind.Aggregate => new AggregatePingTracker(
+                    this.config, this.addressDetector, this.pluginLog, this.gameInteropProvider),
                 PingTrackerKind.COM => new ComponentModelPingTracker(this.config, this.addressDetector, this.pluginLog),
                 PingTrackerKind.IpHlpApi => new IpHlpApiPingTracker(this.config, this.addressDetector, this.pluginLog),
                 PingTrackerKind.Packets => new PacketPingTracker(
-                    this.config,
-                    this.addressDetector,
-                    this.pluginLog,
-                    this.gameInteropProvider),
+                    this.config, this.addressDetector, this.pluginLog, this.gameInteropProvider),
                 _ => RequestFallbackPingTracker(kind),
             };
         }
@@ -112,7 +107,7 @@ namespace PingPlugin
         private AggregatePingTracker RequestFallbackPingTracker(PingTrackerKind kind)
         {
             this.pluginLog.Warning($"No valid ping tracker exists for \"{kind}\". Falling back to aggregate tracker.");
-            return new AggregatePingTracker(this.config, this.addressDetector, this.pluginLog);
+            return new AggregatePingTracker(this.config, this.addressDetector, this.pluginLog, this.gameInteropProvider);
         }
 
         private void InitIpc()

--- a/PingPlugin/PingTrackers/AggregatePingTracker.cs
+++ b/PingPlugin/PingTrackers/AggregatePingTracker.cs
@@ -11,13 +11,14 @@ namespace PingPlugin.PingTrackers
     {
         private const string COMTrackerKey = "COM";
         private const string IpHlpApiTrackerKey = "IpHlpApi";
+        private const string PacketTrackerKey = "Packet";
 
         private readonly IDictionary<string, TrackerInfo> trackerInfos;
         private readonly DecisionTree<string> decisionTree;
         private readonly IPluginLog pluginLog;
         private string currentTracker = "";
 
-        public AggregatePingTracker(PingConfiguration config, GameAddressDetector addressDetector, IPluginLog pluginLog)
+        public AggregatePingTracker(PingConfiguration config, GameAddressDetector addressDetector, IPluginLog pluginLog, IGameInteropProvider gameInteropProvider)
             : base(config, addressDetector, PingTrackerKind.Aggregate, pluginLog)
         {
             this.pluginLog = pluginLog;
@@ -40,6 +41,8 @@ namespace PingPlugin.PingTrackers
 
             RegisterTracker(IpHlpApiTrackerKey,
                 new IpHlpApiPingTracker(config, addressDetector, pluginLog) { Verbose = false });
+            RegisterTracker(PacketTrackerKey,
+                new PacketPingTracker(config, addressDetector, pluginLog, gameInteropProvider) { Verbose = false });
 
             // Create decision tree to solve tracker selection problem
             this.decisionTree = new DecisionTree<string>(
@@ -56,8 +59,18 @@ namespace PingPlugin.PingTrackers
                         pass: new DecisionTree<string>(() => TreeResult.Resolve(IpHlpApiTrackerKey)),
                         fail: new DecisionTree<string>(() => TreeResult.Resolve(COMTrackerKey))
                     ),
-                    // Otherwise, default to IpHlpApi
-                    fail: new DecisionTree<string>(() => TreeResult.Resolve(IpHlpApiTrackerKey))
+                    fail: new DecisionTree<string>(
+                        // If both of these trackers report a ping of 0
+                        () => GetTrackerRTT(COMTrackerKey) == 0 && GetTrackerRTT(IpHlpApiTrackerKey) == 0,
+                        // Just use packets (inaccurate)
+                        pass: new DecisionTree<string>(() => TreeResult.Resolve(PacketTrackerKey)),
+                        fail: new DecisionTree<string>(
+                            // Otherwise use the lower ping value, we'll assume it's more accurate
+                            () => GetTrackerRTT(COMTrackerKey) < GetTrackerRTT(IpHlpApiTrackerKey),
+                            pass: new DecisionTree<string>(() => TreeResult.Resolve(COMTrackerKey)),
+                            fail: new DecisionTree<string>(() => TreeResult.Resolve(IpHlpApiTrackerKey))
+                        )
+                    )
                 )
             );
         }

--- a/PingPlugin/PingTrackers/PacketPingTracker.cs
+++ b/PingPlugin/PingTrackers/PacketPingTracker.cs
@@ -39,8 +39,8 @@ public class PacketPingTracker : PingTracker
     {
         while (!token.IsCancellationRequested)
         {
-            NextRTTCalculation(networkModuleRtt);
             await Task.Delay(TimeSpan.FromSeconds(10), token);
+            NextRTTCalculation(networkModuleRtt);
         }
     }
 

--- a/PingPlugin/PingTrackers/PacketPingTracker.cs
+++ b/PingPlugin/PingTrackers/PacketPingTracker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
+using Dalamud.Utility.Signatures;
+using FFXIVClientStructs.FFXIV.Application.Network;
+using PingPlugin.GameAddressDetectors;
+
+namespace PingPlugin.PingTrackers;
+
+public class PacketPingTracker : PingTracker
+{
+    [Signature(
+        "48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 56 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 48 8B F9 40 32 F6",
+        DetourName = nameof(NetworkModuleUpdateDetour))]
+    private readonly Hook<NetworkModuleUpdateDelegate> networkModuleUpdateHook = null!;
+    private unsafe delegate void NetworkModuleUpdateDelegate(NetworkModule* self);
+
+    private uint networkModuleRtt;
+
+    public PacketPingTracker(PingConfiguration config, GameAddressDetector addressDetector,
+        IPluginLog pluginLog, IGameInteropProvider gameInteropProvider) : base(config, addressDetector, PingTrackerKind.Packets, pluginLog)
+    {
+        gameInteropProvider.InitializeFromAttributes(this);
+        networkModuleUpdateHook.Enable();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
+        networkModuleUpdateHook.Dispose();
+        base.Dispose(true);
+    }
+
+    protected override async Task PingLoop(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            NextRTTCalculation(networkModuleRtt);
+            await Task.Delay(TimeSpan.FromSeconds(10), token);
+        }
+    }
+
+    private unsafe void NetworkModuleUpdateDetour(NetworkModule* self)
+    {
+        networkModuleUpdateHook.Original(self);
+        networkModuleRtt = *(uint*)((nint)self + 0xbcc);
+    }
+}

--- a/PingPlugin/PingUI.cs
+++ b/PingPlugin/PingUI.cs
@@ -142,29 +142,30 @@ namespace PingPlugin
 
             ImGui.Spacing();
 
-            var trackerKinds = Enum.GetValues<PingTrackerKind>();
-            var trackerNames = trackerKinds.Where(t => t != PingTrackerKind.Packets).Select(t => t.FormatName())
+            var isWine = WineDetector.IsWINE();
+            var trackerKinds = Enum.GetValues<PingTrackerKind>()
+                .Where(t => !isWine || t is PingTrackerKind.IpHlpApi or PingTrackerKind.Packets)
                 .ToArray();
-            var tracker = (int)this.pingTracker.Kind;
+            var trackerNames = trackerKinds
+                .Select(t => t.FormatName())
+                .ToArray();
+            var trackerIndex = Array.IndexOf(trackerKinds, this.pingTracker.Kind);
 
-            using (var _ = ImRaii.Disabled(WineDetector.IsWINE()))
+            if (ImGui.Combo(Loc.Localize("PingTracker", "Ping Tracker"), ref trackerIndex, trackerNames,
+                    trackerNames.Length))
             {
-                if (ImGui.Combo(Loc.Localize("PingTracker", "Ping Tracker"), ref tracker, trackerNames,
-                        trackerNames.Length))
-                {
-                    var trackerKind = (PingTrackerKind)tracker;
+                var trackerKind = trackerKinds[trackerIndex];
 
-                    this.config.TrackingMode = trackerKind;
-                    this.config.Save();
+                this.config.TrackingMode = trackerKind;
+                this.config.Save();
 
-                    this.pingTracker = this.requestPingTracker(trackerKind);
-                }
+                this.pingTracker = this.requestPingTracker(trackerKind);
             }
 
-            if (WineDetector.IsWINE() && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            {
-                ImGui.SetTooltip(Loc.Localize("WineDetected", "Locked to Win32 tracker under Wine for compatibility."));
-            }
+            // if (WineDetector.IsWINE() && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            // {
+            //     ImGui.SetTooltip(Loc.Localize("WineDetected", "Locked to Win32 tracker under Wine for compatibility."));
+            // }
 
             ImGui.Spacing();
 


### PR DESCRIPTION
Done by reading the current RTT tracked internally by the game off `NetworkModule`. The signature to the relevant code is `0F B7 40 ?? 2D` (7.55hf1).

Caveats with packet ping tracking applies, but IMO it's more useful to take into account TCP latency and delays in packet processing from, for example, server processing or client on low framerate. Also gives more accurate readings for proxies and gaming VPNs, since they might not catch ICMP pings.
